### PR TITLE
ENG-1675 Update nodeslave to Java 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@ FROM node:0.12
 # list of available versions: http://maven.jenkins-ci.org/content/repositories/releases/org/jenkins-ci/plugins/swarm-client/
 ENV SWARM_VERSION=2.0
 
-RUN \
-    apt-get update && \
-    apt-get -y install openjdk-7-jdk git ssh-client && \
-    npm install -g gulp semistandard bower && \
-    curl -o /swarm.jar http://maven.jenkins-ci.org/content/repositories/releases/org/jenkins-ci/plugins/swarm-client/${SWARM_VERSION}/swarm-client-${SWARM_VERSION}-jar-with-dependencies.jar && \
-    rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin
+RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
+RUN apt-get update && apt-get -y install git ssh-client
+RUN apt-get install -y -t jessie-backports openjdk-8-jdk
+RUN npm install -g gulp semistandard bower
+RUN curl -o /swarm.jar https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/${SWARM_VERSION}/swarm-client-${SWARM_VERSION}-jar-with-dependencies.jar
+RUN rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin
 
 CMD java -jar /swarm.jar -username $JENKINS_USERNAME -password $JENKINS_APIKEY -labels 'node swarm'


### PR DESCRIPTION
Ensure we're running Java 8 to support the latest LTS version of Jenkins
which has changed the required version from 7 to 8